### PR TITLE
tests/expr-propagate2.lst: This test triggers invalid expr propagation.

### DIFF
--- a/tests/expr-propagate2.lst
+++ b/tests/expr-propagate2.lst
@@ -1,0 +1,10 @@
+# Expression propagation state should be properly updated even in the presence
+# of type casts.
+10   $a1 = 0xFFF
+11   $a2 = data_0x20F000
+12   (u32)$a2 = *(u32*)$a2 & $a1
+13   if ($a2 == 0) goto exit
+14   $a3 = data_0x20F004
+15   *(u32*)$a3 = 0
+15 exit:
+16   return

--- a/tests/expr-propagate2.lst.exp.bb
+++ b/tests/expr-propagate2.lst.exp.bb
@@ -1,0 +1,22 @@
+// Graph props:
+//  name: None
+//  trailing_jumps: True
+
+// Predecessors: []
+10:
+$a1 = 0xfff
+$a2 = data_0x20F000
+(u32)$a2 = *(u32*)$a2 & $a1
+if ($a2 == 0) goto 15
+Exits: [(COND(EXPR(==[$a2, 0])), '15'), (None, '14')]
+
+// Predecessors: ['10']
+14:
+$a3 = data_0x20F004
+*(u32*)$a3 = 0
+Exits: [(None, '15')]
+
+// Predecessors: ['10', '14']
+15:
+return
+Exits: []


### PR DESCRIPTION
The issue is caused by the type cast in the destination operand of the instruction in the 12th line. For a detailed description, refer to #22.