### PR TITLE
decomp: split_node: Fix deepcopy import.

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,6 +1,6 @@
 import sys
 from graph import Graph
-from copy import copy
+import copy
 
 import utils
 
@@ -664,7 +664,7 @@ class Inst:
         if self.op == "=" and not is_expr(self.args[0]):
             s += "%s = %s" % (self.dest, self.args[0])
         else:
-            e = copy(self.args[0])
+            e = copy.copy(self.args[0])
             args = e.args
             op = e.op
             if not (op == "!" or op[0].isalpha()):


### PR DESCRIPTION
I encountered an input that triggers the following import failure in decomp:split_node():

```
Error while processing file: sub_204bdc.lst
Traceback (most recent call last):
  File "apply_xform.py", line 229, in <module>
    changed = one_iter(input, output, iter_no)
  File "apply_xform.py", line 191, in one_iter
    handle_file(args)
  File "apply_xform.py", line 68, in handle_file
    raise e
  File "apply_xform.py", line 65, in handle_file
    handle_file_unprotected(args)
  File "apply_xform.py", line 93, in handle_file_unprotected
    mod.apply(cfg)
  File "/Users/maxim/Documents/Development/ScratchABlock_maxim/script_decompile.py", line 97, in apply
    if match_abnormal_sel(cfg):
  File "/Users/maxim/Documents/Development/ScratchABlock_maxim/decomp.py", line 458, in match_abnormal_sel
    split_node(cfg, v)
  File "/Users/maxim/Documents/Development/ScratchABlock_maxim/decomp.py", line 35, in split_node
    node2_props = copy.deepcopy(node_props)
AttributeError: 'function' object has no attribute 'deepcopy'
```
It looks like something "shadows" python's copy. Hence this simple fix.