### PR TITLE
Add PowerPC arch.

### DIFF
--- a/arch_ppc32.py
+++ b/arch_ppc32.py
@@ -1,0 +1,43 @@
+from core import ADDR, REG
+from archutils import *
+
+
+BITNESS = 32
+ENDIANNESS = "big"
+
+ALL_REGS = {REG("r0"), REG("sp"), REG("rtoc")} | reg_range("r", 3, 31)
+
+
+def call_params(addr):
+    return reg_range("r", 3, 10)
+
+
+def param_filter(regs):
+    # Assume for now that all parameters will be passed in registers.
+    # This must be good enough to cover the most usage cases.
+    # The following cases will break it:
+    # - functions accepting more then 8 params
+    # - functions accepting floating-point params
+    # - variadic functions
+    return reg_continuous_subrange(regs, reg_range("r", 3, 10))
+
+
+def call_ret(addr):
+    return {REG("r3")}
+
+
+def ret_filter(regs):
+    # Assuming there is no floating-point stuff
+    return {REG("r3")}
+
+
+def call_save(addr):
+    return reg_range("r", 13, 31) | {REG("sp")}
+
+
+def call_defs(addr):
+    return call_ret(addr) | (ALL_REGS - call_save(addr))
+
+
+def ret_uses(cfg):
+    return set()


### PR DESCRIPTION
Below my first attempt at the PowerPC arch descriptor. It has some limitations described in the source.

The most difficult decision is the proper name for this arch. For the moment being, it describes the calling convention Apple borrowed from IBM and used in Mac OS until 2002.

Mac OS X, introduced around 2000, uses a similar calling convention in its Mach-O format. The most notably difference between them is the usage of R2:
- in the old Mac OS and IBM, R2 holds the pointer to the data section descriptor ("TOC" - table of content, hence the name "RTOC" for R2). R2 will be passed around to each call and thus acts like an implicit parameter (SaBl recognizes this case automatically).
- in Mach-O, R2 is considered a general purpose register while the program data is accessed differently (via position independent code).

What's the best solution to this problem? Two different archs ("ppc32-peff" and "ppc32-macho")?
Moreover, there is Linux PPC. I have no clue which calling convention is used there...